### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/muller/dataio/genotypecollection.py
+++ b/muller/dataio/genotypecollection.py
@@ -59,9 +59,9 @@ class GenotypeCollection(collections.UserDict):
 			all_annotations = [i.annotations for i in self.values()]
 			available = sorted(itertools.chain.from_iterable(all_annotations))
 			try:
-				from fuzzywuzzy import process
-				similar = process.extract(value, available)
-				similar = [i[0] for i in similar if i[1] > 80]
+				from rapidfuzz import process
+				similar = process.extract(value, available, score_cutoff=80)
+				similar = [i[0] for i in similar]
 			except ModuleNotFoundError:
 				similar = [i for i in available if value in i]
 			if similar:

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
 	],
 	extras_require = {
 		'Additional support for parsing files': ['beautifulsoup4'],
-		'List similar annotations when selecting genotypes': ['fuzzywuzzy'],
+		'List similar annotations when selecting genotypes': ['rapidfuzz'],
 		'Generate composite graphs from the genotye/lineage/timeseries plots': ["pillow"],
 		'To run tests': ["pytest"]
 	},


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefor MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it faster than FuzzyWuzzy.